### PR TITLE
CI: Build and pypi publish

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -56,4 +56,7 @@ depends_on:
 
 trigger:
   branch:
-  - master
+    - master
+  event:
+    exclude:
+      - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,7 @@ steps:
     - make dist
     - pip3 install pipenv
     - pipenv install
+    - pipenv sync
     - pipenv install dist/delugeClient-kevin-0.3.1-py3-none-any.whl
 #     - pipenv install pytest
 
@@ -48,6 +49,7 @@ steps:
     - make dist
     - pip3 install pipenv
     - pipenv install
+    - pipenv sync
     - pipenv install dist/delugeClient-kevin-0.3.1-py3-none-any.whl
 #     - pipenv install pytest
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -58,3 +58,9 @@ trigger:
   event:
     exclude:
       - pull_request
+
+---
+kind: signature
+hmac: 08793426ddd2274e2de166144dc15cd63fe6a2c0fd47382d28f20ececee84898
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,36 +31,6 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: Build and test arm64
-
-platform:
-  os: linux
-  arch: arm64
-
-steps:
-  - name: Build source
-    image: python:3.10
-    commands:
-    - make build
-
-  - name: Install
-    image: python:3.10
-    commands:
-    - make dist
-    - pip3 install pipenv
-    - pipenv install
-    - pipenv sync
-    - pipenv install dist/delugeClient_kevin-0.3.1-py3-none-any.whl
-#     - pipenv install pytest
-
-#   - name: Run tests
-#     image: python:3.10
-#     commands:
-#       pipenv run pytest
-
----
-kind: pipeline
-type: docker
 name: Publish package to PyPi
 
 platform:
@@ -83,3 +53,6 @@ steps:
     - pip3 install pipenv
     - pipenv install twine
     # - pipenv run twine upload dist/*
+
+depends_on:
+  - Build and test amd64

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,10 +17,8 @@ steps:
     image: python:3.10
     commands:
     - make dist
-    - pip3 install pipenv
-    - pipenv install
-    - pipenv sync
-    - pipenv install dist/delugeClient_kevin-0.3.1-py3-none-any.whl
+    - pip3 install -r requirements.txt
+    - pip3 install dist/*.whl
 #     - pipenv install pytest
 
 #   - name: Run tests

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ steps:
     commands:
     - make dist
     - pip3 install pipenv
-    - install dist/delugeClient-kevin-*-py3-none-any.whl
+    - pipenv install dist/delugeClient-kevin-*-py3-none-any.whl
 #     - pipenv install pytest
 
 #   - name: Run tests
@@ -46,7 +46,7 @@ steps:
     commands:
     - make dist
     - pip3 install pipenv
-    - install dist/delugeClient-kevin-*-py3-none-any.whl
+    - pipenv install dist/delugeClient-kevin-*-py3-none-any.whl
 #     - pipenv install pytest
 
 #   - name: Run tests

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ steps:
     commands:
     - make dist
     - pip3 install pipenv
-    - pipenv install dist/delugeClient-kevin-*-py3-none-any.whl
+    - pipenv install dist/delugeClient-kevin-0.3.1-py3-none-any.whl
 #     - pipenv install pytest
 
 #   - name: Run tests
@@ -46,7 +46,7 @@ steps:
     commands:
     - make dist
     - pip3 install pipenv
-    - pipenv install dist/delugeClient-kevin-*-py3-none-any.whl
+    - pipenv install dist/delugeClient-kevin-0.3.1-py3-none-any.whl
 #     - pipenv install pytest
 
 #   - name: Run tests

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,24 +44,12 @@ steps:
       - pip3 install delugeClient-kevin -q -q
       - bash publish_version?.sh
 
-  - name: Test PyPi publish
-    image: python:3.10
-    commands: 
-      - make dist
-      - pip3 install -r requirements.txt
-      - pip3 install twine
-      - twine check dist/*
-      - twine upload --repository delugeClient-kevin dist/*
-
   - name: PyPi publish
     image: python:3.10
     commands: 
     - make dist
-    - pip3 install pipenv
-    - pipenv install
-    - pipenv sync
-    - pipenv install twine
-    # - pipenv run twine upload dist/*
+    - pip3 install twine
+    - twine upload dist/*
 
 depends_on:
   - Build and test amd64

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,14 +1,81 @@
 ---
 kind: pipeline
 type: docker
-name: delugeClient
+name: Build and test amd64
 
 platform:
   os: linux
   arch: amd64
 
 steps:
-  - name: Build package
-    image: python:3.10
-    commands:
-      - make build
+- name: Build source
+  image: python:3.10
+  commands:
+  - make build
+
+- name: Install
+  image: python:3.10
+  commands:
+  - make dist
+  - pip3 install pipenv
+  - install dist/delugeClient-kevin-*-py3-none-any.whl
+#   - pipenv install pytest
+
+# - name: Run tests
+#   image: python:3.10
+#   commands:
+#     pipenv run pytest
+
+---
+kind: pipeline
+type: docker
+name: Build and test arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Build source
+  image: python:3.10
+  commands:
+  - make build
+
+- name: Install
+  image: python:3.10
+  commands:
+  - make dist
+  - pip3 install pipenv
+  - install dist/delugeClient-kevin-*-py3-none-any.whl
+#   - pipenv install pytest
+
+# - name: Run tests
+#   image: python:3.10
+#   commands:
+#     pipenv run pytest
+
+---
+kind: pipeline
+type: docker
+name: publish package to PyPi
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: Test PyPi publish
+  image: python:3.10
+  commands: 
+  - make dist
+  - pip3 install pipenv
+  - pipenv install twine
+  - pipenv run twine upload --repository delugeClient-kevin dist/*
+
+- name: Test PyPi publish
+  image: python:3.10
+  commands: 
+  - make dist
+  - pip3 install pipenv
+  - pipenv install twine
+  # - pipenv run twine upload dist/*

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,23 +8,23 @@ platform:
   arch: amd64
 
 steps:
-- name: Build source
-  image: python:3.10
-  commands:
-  - make build
+  - name: Build source
+    image: python:3.10
+    commands:
+    - make build
 
-- name: Install
-  image: python:3.10
-  commands:
-  - make dist
-  - pip3 install pipenv
-  - install dist/delugeClient-kevin-*-py3-none-any.whl
-#   - pipenv install pytest
+  - name: Install
+    image: python:3.10
+    commands:
+    - make dist
+    - pip3 install pipenv
+    - install dist/delugeClient-kevin-*-py3-none-any.whl
+#     - pipenv install pytest
 
-# - name: Run tests
-#   image: python:3.10
-#   commands:
-#     pipenv run pytest
+#   - name: Run tests
+#     image: python:3.10
+#     commands:
+#       pipenv run pytest
 
 ---
 kind: pipeline
@@ -36,46 +36,46 @@ platform:
   arch: arm64
 
 steps:
-- name: Build source
-  image: python:3.10
-  commands:
-  - make build
+  - name: Build source
+    image: python:3.10
+    commands:
+    - make build
 
-- name: Install
-  image: python:3.10
-  commands:
-  - make dist
-  - pip3 install pipenv
-  - install dist/delugeClient-kevin-*-py3-none-any.whl
-#   - pipenv install pytest
+  - name: Install
+    image: python:3.10
+    commands:
+    - make dist
+    - pip3 install pipenv
+    - install dist/delugeClient-kevin-*-py3-none-any.whl
+#     - pipenv install pytest
 
-# - name: Run tests
-#   image: python:3.10
-#   commands:
-#     pipenv run pytest
+#   - name: Run tests
+#     image: python:3.10
+#     commands:
+#       pipenv run pytest
 
 ---
 kind: pipeline
 type: docker
-name: publish package to PyPi
+name: Publish package to PyPi
 
 platform:
   os: linux
   arch: amd64
 
 steps:
-- name: Test PyPi publish
-  image: python:3.10
-  commands: 
-  - make dist
-  - pip3 install pipenv
-  - pipenv install twine
-  - pipenv run twine upload --repository delugeClient-kevin dist/*
+  - name: Test PyPi publish
+    image: python:3.10
+    commands: 
+    - make dist
+    - pip3 install pipenv
+    - pipenv install twine
+    - pipenv run twine upload --repository delugeClient-kevin dist/*
 
-- name: Test PyPi publish
-  image: python:3.10
-  commands: 
-  - make dist
-  - pip3 install pipenv
-  - pipenv install twine
-  # - pipenv run twine upload dist/*
+  - name: PyPi publish
+    image: python:3.10
+    commands: 
+    - make dist
+    - pip3 install pipenv
+    - pipenv install twine
+    # - pipenv run twine upload dist/*

--- a/.drone.yml
+++ b/.drone.yml
@@ -65,3 +65,7 @@ steps:
 
 depends_on:
   - Build and test amd64
+
+trigger:
+  branch:
+  - master

--- a/.drone.yml
+++ b/.drone.yml
@@ -38,14 +38,19 @@ platform:
   arch: amd64
 
 steps:
+  - name: Newer version to publish?
+    image: python:3.10
+    commands:
+      - bash publish_version?.sh
+
   - name: Test PyPi publish
     image: python:3.10
     commands: 
-    - make dist
-    - pip3 install -r requirements.txt
-    - pip3 install twine
-    - twine check dist/*
-    - twine upload --repository delugeClient-kevin dist/*
+      - make dist
+      - pip3 install -r requirements.txt
+      - pip3 install twine
+      - twine check dist/*
+      - twine upload --repository delugeClient-kevin dist/*
 
   - name: PyPi publish
     image: python:3.10

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,6 +18,7 @@ steps:
     commands:
     - make dist
     - pip3 install pipenv
+    - pipenv install
     - pipenv install dist/delugeClient-kevin-0.3.1-py3-none-any.whl
 #     - pipenv install pytest
 
@@ -46,6 +47,7 @@ steps:
     commands:
     - make dist
     - pip3 install pipenv
+    - pipenv install
     - pipenv install dist/delugeClient-kevin-0.3.1-py3-none-any.whl
 #     - pipenv install pytest
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -42,11 +42,10 @@ steps:
     image: python:3.10
     commands: 
     - make dist
-    - pip3 install pipenv
-    - pipenv install
-    - pipenv sync
-    - pipenv install twine
-    - pipenv run twine upload --repository delugeClient-kevin dist/*
+    - pip3 install -r requirements.txt
+    - pip3 install twine
+    - twine check dist/*
+    - twine upload --repository delugeClient-kevin dist/*
 
   - name: PyPi publish
     image: python:3.10

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,6 +43,8 @@ steps:
     commands: 
     - make dist
     - pip3 install pipenv
+    - pipenv install
+    - pipenv sync
     - pipenv install twine
     - pipenv run twine upload --repository delugeClient-kevin dist/*
 
@@ -51,6 +53,8 @@ steps:
     commands: 
     - make dist
     - pip3 install pipenv
+    - pipenv install
+    - pipenv sync
     - pipenv install twine
     # - pipenv run twine upload dist/*
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ steps:
   - name: Newer version to publish?
     image: python:3.10
     commands:
-      - pip3 install delugeClient-kevin
+      - pip3 install delugeClient-kevin -q -q
       - bash publish_version?.sh
 
   - name: Test PyPi publish

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ steps:
     - pip3 install pipenv
     - pipenv install
     - pipenv sync
-    - pipenv install dist/delugeClient-kevin-0.3.1-py3-none-any.whl
+    - pipenv install dist/delugeClient_kevin-0.3.1-py3-none-any.whl
 #     - pipenv install pytest
 
 #   - name: Run tests
@@ -50,7 +50,7 @@ steps:
     - pip3 install pipenv
     - pipenv install
     - pipenv sync
-    - pipenv install dist/delugeClient-kevin-0.3.1-py3-none-any.whl
+    - pipenv install dist/delugeClient_kevin-0.3.1-py3-none-any.whl
 #     - pipenv install pytest
 
 #   - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,13 @@ install:
 build:
 	python3 setup.py build
 
-dist:
+tarball:
 	python3 setup.py sdist
+
+wheel:
+	python3 setup.py bdist_wheel
+
+dist: tarball wheel
 
 upload: clean dist
 	twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -4,23 +4,20 @@
 
 <h4 align="center"> A easy to use Deluge CLI that can connect to Deluge RPC (even over ssh) written entirely in python.</h4>
 
-| Tested version | PyPi package | Drone CI |
+| Tested version | PyPi package | License |
 |:--------|:------|:------|
-| [![PyVersion](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/) | [![PyPI](https://img.shields.io/pypi/v/delugeClient_kevin)](https://pypi.org/project/delugeClient_kevin/) | [![Build Status](https://drone.schleppe.cloud/api/badges/KevinMidboe/delugeClient/status.svg)](https://drone.schleppe.cloud/KevinMidboe/delugeClient)
+| [![PyVersion](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/) | [![PyPI](https://img.shields.io/pypi/v/delugeClient_kevin)](https://pypi.org/project/delugeClient_kevin/) |[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-
-| Known vulnerabilities | License |
+| Drone CI | Known vulnerabilities |
 |:--------|:------|
-| [![Known Vulnerabilities](https://snyk.io/test/github/kevinmidboe/delugeClient/badge.svg?targetFile=requirements.txt)](https://snyk.io/test/github/kevinmidboe/delugeClient?targetFile=requirements.txt) |[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-
+| [![Build Status](https://drone.schleppe.cloud/api/badges/KevinMidboe/delugeClient/status.svg)](https://drone.schleppe.cloud/KevinMidboe/delugeClient) | [![Known Vulnerabilities](https://snyk.io/test/github/kevinmidboe/delugeClient/badge.svg?targetFile=requirements.txt)](https://snyk.io/test/github/kevinmidboe/delugeClient?targetFile=requirements.txt)
 
 <p align="center">
   <a href="#abstract">Abstract</a> •
-  <a href="#setup_virtualenv">Setup virtualenv</a> •
-  <a href="#configure">Configure</a> •
-  <a href="#installation">Install dependencies</a> •
+  <a href="#install">Install</a> •
   <a href="#usage">Usage</a> •
-  <a href="#running">Running</a> •
+  <a href="#setup_virtualenv">Setup Virtual Environment</a> •
+  <a href="#configure">Configure</a> •
   <a href="#contributing">Contributing</a>
 </p>
 
@@ -28,6 +25,44 @@
 ## <a name="abstract"></a> Abstract
 Create a deluge python client for interfacing with deluge for common tasks like listing, adding, removing and setting download directory for torrents. 
 
+## <a name="install"></a> Install
+Install from source:
+```bash
+python3 setup.py install
+```
+
+Install from pip:
+```bash
+pip3 install delugeClient-kevin
+```
+
+## <a name="usage"></a> Usage
+View delugeClient cli options with `delugeClient --help`:
+
+```
+ Usage: python -m delugeclient [OPTIONS] COMMAND [ARGS]...
+
+╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --debug                       Set log level to debug                                                            │
+│ --info                        Set log level to info                                                             │
+│ --warning                     Set log level to warning                                                          │
+│ --error                       Set log level to error                                                            │
+│ --install-completion          Install completion for the current shell.                                         │
+│ --show-completion             Show completion for the current shell, to copy it or customize the installation.  │
+│ --help                        Show this message and exit.                                                       │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ──────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ add                Add magnet torrent                                                                           │
+│ disk               Get free disk space                                                                          │
+│ get                Get torrent by id or hash                                                                    │
+│ ls                 List all torrents                                                                            │
+│ remove             Remove torrent by id or hash                                                                 │
+│ rm                 Remove torrent by name                                                                       │
+│ search             Search for string segment in torrent name                                                    │
+│ toggle             Toggle torrent download state                                                                │
+│ version            Print package version                                                                        │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
 
 ## <a name="setup_virtualenv"></a> Setup Virtual Environment
 Virtual environment allows us to create a local environment for the requirements needed. Because pip does not download packages already downloaded to your system, we can use virtualenv to save our packages in the project folder.
@@ -41,7 +76,7 @@ To install virtualenv, simply run:
 ```
 
 
-### Usage
+### Virtualenv setup
 After you have downloaded this project go to it in your terminal by going to the folder you downloaded and typing the following:
 
 
@@ -57,8 +92,6 @@ The to setup a virtual environment enter this:
 
  > If you get an error now it might be because you don't have python3.10, please make sure you have python version 3.10 if else you can download it from [here](https://www.python.org/downloads/)
 
-
-First we navigate to the folder we downloaded.
 
 Then we use the ```virtualenv``` command to create a ```env``` subdirectory in our project. This is where pip will download everything to and where we can add other specific python versions. Then we need to *activate* our virtual environment by doing:
 
@@ -95,51 +128,6 @@ Then you need to change the HOST and PORT to reflect the address for your deluge
 ```
  $ cat /home/USER/.config/deluge/auth
 ```
-
-
-## <a name="install"></a> Install Required Dependencies
-Now that we have our virutalenv set up and activated we want to install all the necessary packages listed in `requirements.txt`. To install it's dependencies do the following:
-
-```
- $ pip install -r requirements.txt
-```
-
-Now we have our neccessary packages installed!
-
-
-## <a name="usage"></a> Usage
-
-```
-Custom delugeRPC client
-Usage:
-   deluge_cli add MAGNET [DIR] [--debug | --warning | --error]
-   deluge_cli get TORRENT
-   deluge_cli ls [--downloading | --seeding | --paused]
-   deluge_cli toggle TORRENT
-   deluge_cli rm TORRENT [--debug | --warning | --error]
-   deluge_cli (-h | --help)
-   deluge_cli --version
-
-Arguments:
-   MAGNET        Magnet link to add
-   DIR           Directory to save to
-   TORRENT       A selected torrent
-
-Options:
-   -h --help     Show this screen
-   --version     Show version
-   --debug       Print all debug log
-   --warning     Print only logged warnings
-   --error       Print error messages (Error/Warning)
-```
-
-### <a name="running"></a> Running
-To interface with deluged :
-
-```
- $ ./deluge_cli.py ls
-```
-
 
 ## <a name="contributing"></a> Contributing
 - Fork it!

--- a/delugeClient/__version__.py
+++ b/delugeClient/__version__.py
@@ -1,1 +1,4 @@
 __version__ = '0.3.1'
+
+if __name__ == '__main__':
+  print(__version__)

--- a/delugeClient/__version__.py
+++ b/delugeClient/__version__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 if __name__ == '__main__':
   print(__version__)

--- a/publish_version?.sh
+++ b/publish_version?.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+PYPI_VERSION=$(pip3 show delugeClient-kevin | awk '$1 ~ /Version:/ { print $2 }')
+SOURCE_VERSION=$(python3 delugeClient/__version__.py)
+
+echo "hello"
+echo "pypi version: $PYPI_VERSION"
+echo "source version: $SOURCE_VERSION"
+
+function version {
+  echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
+}
+
+if [ $(version $SOURCE_VERSION) -gt $(version $PYPI_VERSION) ]; then
+  echo "source is newer than pypi"
+  exit 0
+else
+  exit 1
+  echo "source is same or oldre, but not newer"
+fi

--- a/publish_version?.sh
+++ b/publish_version?.sh
@@ -3,18 +3,17 @@
 PYPI_VERSION=$(pip3 show delugeClient-kevin | awk '$1 ~ /Version:/ { print $2 }')
 SOURCE_VERSION=$(python3 delugeClient/__version__.py)
 
-echo "hello"
-echo "pypi version: $PYPI_VERSION"
-echo "source version: $SOURCE_VERSION"
+printf "Source version:\t\t %s\n" $SOURCE_VERSION
+printf "Remote PyPi version:\t %s\n" $PYPI_VERSION
 
 function version {
   echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
 }
 
 if [ $(version $SOURCE_VERSION) -gt $(version $PYPI_VERSION) ]; then
-  echo "source is newer than pypi"
+  echo "Soure is newer than remote, publishing!"
   exit 0
 else
+  echo "Source is same or oldre than remote, nothing to do."
   exit 1
-  echo "source is same or oldre, but not newer"
 fi

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
   classifiers=[
     'Programming Language :: Python',
     'Operating System :: OS Independent',
+    'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 3.10',
   ],
   entry_points={


### PR DESCRIPTION
Reconfigure build step, commented testing setup for when pytest is setup & publish to pypi step.

PyPi publish checks the latest version available from PyPi and compares with local __version__.py. If local version is newer, publish to PyPi. 

Bumps package version to: `v0.3.2`