### PR TITLE
CI: PyPi publish to test & by token

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -42,12 +42,36 @@ steps:
       - pip3 install delugeClient-kevin -q -q
       - bash publish_version?.sh
 
-  - name: PyPi publish
-    image: python:3.10
-    commands: 
-    - make dist
-    - pip3 install twine
-    - twine upload dist/*
+  - name: PyPi verify
+    image: python3.10
+    commands:
+      - make dist
+      - pip3 install twine
+      - twine check dist/*
+
+  - name: PyPi test publish
+    image: python3.10
+    environment:
+      TWINE_USERNAME:
+        from_secret: TWINE_USERNAME
+      TWINE_PASSWORD:
+        from_secret: TWINE_TEST_PASSWORD
+    commands:
+      - make dist
+      - pip3 install twine
+      - twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+  # - name: PyPi publish
+  #   image: python:3.10
+  #   environment:
+  #     TWINE_USERNAME:
+  #       from_secret: TWINE_USERNAME
+  #     TWINE_PASSWORD:
+  #       from_secret: TWINE_TEST_PASSWORD
+  #   commands:
+  #     - make dist
+  #     - pip3 install twine
+  #     - twine upload dist/*
 
 depends_on:
   - Build and test amd64

--- a/.drone.yml
+++ b/.drone.yml
@@ -79,6 +79,7 @@ depends_on:
 trigger:
   branch:
     - master
+    - ci/pypi-publish-by-token
   event:
     exclude:
       - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -61,17 +61,17 @@ steps:
       - pip3 install twine
       - twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
-  # - name: PyPi publish
-  #   image: python:3.10
-  #   environment:
-  #     TWINE_USERNAME:
-  #       from_secret: TWINE_USERNAME
-  #     TWINE_PASSWORD:
-  #       from_secret: TWINE_TEST_PASSWORD
-  #   commands:
-  #     - make dist
-  #     - pip3 install twine
-  #     - twine upload dist/*
+  - name: PyPi publish
+    image: python:3.10
+    environment:
+      TWINE_USERNAME:
+        from_secret: TWINE_USERNAME
+      TWINE_PASSWORD:
+        from_secret: TWINE_PASSWORD
+    commands:
+      - make dist
+      - pip3 install twine
+      - twine upload dist/*
 
 depends_on:
   - Build and test amd64
@@ -79,13 +79,12 @@ depends_on:
 trigger:
   branch:
     - master
-    - ci/pypi-publish-by-token
   event:
     exclude:
       - pull_request
 
 ---
 kind: signature
-hmac: 819ef0e296a78503c4ff1fb08a5a4f52d2d96ccc88cee60c44c7253860fc4971
+hmac: 60604a21f35e11d078d5d381bbea8e25b903175c018ba9e6f4a4379285e89883
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -86,6 +86,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 08793426ddd2274e2de166144dc15cd63fe6a2c0fd47382d28f20ececee84898
+hmac: f0bcccc150938c350ff774024538d6d4c7da56ce6724e16f36fb177709cc15a0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,14 +43,14 @@ steps:
       - bash publish_version?.sh
 
   - name: PyPi verify
-    image: python3.10
+    image: python:3.10
     commands:
       - make dist
       - pip3 install twine
       - twine check dist/*
 
   - name: PyPi test publish
-    image: python3.10
+    image: python:3.10
     environment:
       TWINE_USERNAME:
         from_secret: TWINE_USERNAME
@@ -86,6 +86,6 @@ trigger:
 
 ---
 kind: signature
-hmac: f0bcccc150938c350ff774024538d6d4c7da56ce6724e16f36fb177709cc15a0
+hmac: 819ef0e296a78503c4ff1fb08a5a4f52d2d96ccc88cee60c44c7253860fc4971
 
 ...


### PR DESCRIPTION
Reads username and password (token) from secret for twine upload to PyPi. 

Also setup publish to test.pypi.org.