### PR TITLE
Feat: Importable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip3 install delugeClient-kevin
 ```
 
 ## <a name="usage"></a> Usage
-View delugeClient cli options with `delugeClient --help`:
+View delugeClient cli options with `delugeclient --help`:
 
 ```
  Usage: python -m delugeclient [OPTIONS] COMMAND [ARGS]...
@@ -62,6 +62,13 @@ View delugeClient cli options with `delugeClient --help`:
 │ toggle             Toggle torrent download state                                                                │
 │ version            Print package version                                                                        │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+### Running from source
+Run from source for fun or during development using module flag:
+
+```
+python3 -m delugeClient --help
 ```
 
 ## <a name="setup_virtualenv"></a> Setup Virtual Environment

--- a/README.md
+++ b/README.md
@@ -42,26 +42,26 @@ View delugeClient cli options with `delugeclient --help`:
 ```
  Usage: python -m delugeclient [OPTIONS] COMMAND [ARGS]...
 
-╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --debug                       Set log level to debug                                                            │
-│ --info                        Set log level to info                                                             │
-│ --warning                     Set log level to warning                                                          │
-│ --error                       Set log level to error                                                            │
-│ --install-completion          Install completion for the current shell.                                         │
-│ --show-completion             Show completion for the current shell, to copy it or customize the installation.  │
-│ --help                        Show this message and exit.                                                       │
-╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ──────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ add                Add magnet torrent                                                                           │
-│ disk               Get free disk space                                                                          │
-│ get                Get torrent by id or hash                                                                    │
-│ ls                 List all torrents                                                                            │
-│ remove             Remove torrent by id or hash                                                                 │
-│ rm                 Remove torrent by name                                                                       │
-│ search             Search for string segment in torrent name                                                    │
-│ toggle             Toggle torrent download state                                                                │
-│ version            Print package version                                                                        │
-╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ───────────────────────────────────────────────────────────────╮
+│ --debug                       Set log level to debug                    │
+│ --info                        Set log level to info                     │
+│ --warning                     Set log level to warning                  │
+│ --error                       Set log level to error                    │
+│ --install-completion          Install completion for the current shell. │
+│ --show-completion             Show completion for the current shell     │
+│ --help                        Show this message and exit.               │
+╰─────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ──────────────────────────────────────────────────────────────╮
+│ add                Add magnet torrent                                   │
+│ disk               Get free disk space                                  │
+│ get                Get torrent by id or hash                            │
+│ ls                 List all torrents                                    │
+│ remove             Remove torrent by id or hash                         │
+│ rm                 Remove torrent by name                               │
+│ search             Search for string segment in torrent name            │
+│ toggle             Toggle torrent download state                        │
+│ version            Print package version                                │
+╰─────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### Running from source

--- a/delugeClient/__init__.py
+++ b/delugeClient/__init__.py
@@ -2,9 +2,10 @@
 # -*- encoding: utf-8 -*-
 
 from sys import path
-from os.path import dirname, join
+from os.path import dirname, join, abspath
 
-path.append(dirname(__file__))
+SCRIPT_DIR = dirname(abspath(__file__))
+path.append(dirname(SCRIPT_DIR))
 
 import logging
 from utils import BASE_DIR

--- a/delugeClient/__init__.py
+++ b/delugeClient/__init__.py
@@ -8,7 +8,8 @@ SCRIPT_DIR = dirname(abspath(__file__))
 path.append(dirname(SCRIPT_DIR))
 
 import logging
-from utils import BASE_DIR
+from delugeClient.utils import BASE_DIR
+from delugeClient.deluge import Deluge
 
 def addHandler(handler):
   handler.setFormatter(formatter)

--- a/delugeClient/__main__.py
+++ b/delugeClient/__main__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.10
-
 import os
 import sys
 import signal
@@ -8,10 +7,10 @@ import logging
 import typer
 from pprint import pprint
 
-from deluge import Deluge
-from utils import ColorizeFilter, BASE_DIR, validHash, convertFilesize
-from __version__ import __version__
-from __init__ import addHandler
+from delugeClient.deluge import Deluge
+from delugeClient.utils import ColorizeFilter, BASE_DIR, validHash, convertFilesize
+from delugeClient.__version__ import __version__
+from delugeClient.__init__ import addHandler
 
 ch = logging.StreamHandler()
 ch.addFilter(ColorizeFilter())

--- a/delugeClient/__version__.py
+++ b/delugeClient/__version__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 
 if __name__ == '__main__':
   print(__version__)

--- a/delugeClient/deluge.py
+++ b/delugeClient/deluge.py
@@ -9,9 +9,9 @@ import logging.config
 
 from deluge_client import DelugeRPCClient, FailedToReconnectException
 from sshtunnel import SSHTunnelForwarder, BaseSSHTunnelForwarderError
-from utils import getConfig, BASE_DIR
 
-from torrent import Torrent
+from delugeClient.utils import getConfig, BASE_DIR
+from delugeClient.torrent import Torrent
 
 logger = logging.getLogger('deluge_cli')
 

--- a/delugeClient/torrent.py
+++ b/delugeClient/torrent.py
@@ -2,7 +2,7 @@ import json
 import logging
 from distutils.util import strtobool
 
-from utils import convert
+from delugeClient.utils import convert
 
 logger = logging.getLogger('deluge_cli')
 


### PR DESCRIPTION
Allows the package to be imported correctly. 

Was experiencing issues when importing from another project that had the same filenames, e.g. `utils.py`. Fixed by prefixing package name to all local file imports.